### PR TITLE
feat: add automation and link spam behavioral checks

### DIFF
--- a/backend/app/services/detectors/behavioral_detector.py
+++ b/backend/app/services/detectors/behavioral_detector.py
@@ -172,7 +172,7 @@ class BehavioralDetector(BaseDetector):
             )
         if account_data.get("bot"):
             now = datetime.utcnow()
-            public_items = [s for s in items if s.get("visibility") != "unlisted"]
+            public_items = [s for s in items if s.get("visibility") not in ("unlisted", "private", "direct")]
             posts_last_hour = sum(
                 1 for s in public_items if self._parse_time(s["created_at"]) >= now - timedelta(hours=1)
             )

--- a/backend/app/services/detectors/behavioral_detector.py
+++ b/backend/app/services/detectors/behavioral_detector.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import re
 from urllib.parse import urlparse
 from typing import Any
+from urllib.parse import urlparse
 
 from sqlalchemy.orm import Session
 

--- a/backend/app/services/detectors/behavioral_detector.py
+++ b/backend/app/services/detectors/behavioral_detector.py
@@ -1,6 +1,9 @@
 """Behavioral detector for account behavior analysis."""
 
 from datetime import datetime, timedelta
+import re
+from urllib.parse import urlparse
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -13,20 +16,14 @@ from app.services.detectors.base import BaseDetector
 class BehavioralDetector(BaseDetector):
     """Detector for behavioral patterns in account activity."""
 
-    def evaluate(self, rule: Rule, account_data: dict[str, any], statuses: list[dict[str, any]]) -> list[Violation]:
-        """Evaluate account behavior against rule patterns."""
+    def evaluate(self, rule: Rule, account_data: dict[str, Any], statuses: list[dict[str, Any]]) -> list[Violation]:
         violations: list[Violation] = []
         mastodon_account_id = account_data.get("mastodon_account_id")
-
         if not mastodon_account_id:
             return violations
-
         with Session(engine) as session:
-            # Use rule.pattern to determine which behavior to check
             behavior_type = rule.pattern.lower().strip()
-
             if behavior_type == "rapid_posting":
-                # Check for rapid posting behavior
                 one_hour_ago = datetime.utcnow() - timedelta(hours=1)
                 posts_last_1h = (
                     session.query(InteractionHistory)
@@ -36,7 +33,6 @@ class BehavioralDetector(BaseDetector):
                     )
                     .count()
                 )
-
                 if posts_last_1h >= rule.trigger_threshold:
                     violations.append(
                         Violation(
@@ -49,9 +45,7 @@ class BehavioralDetector(BaseDetector):
                             ),
                         )
                     )
-
             elif behavior_type == "interaction_spam":
-                # Check for unusual interaction patterns (many interactions with different accounts)
                 recent_interactions = (
                     session.query(InteractionHistory)
                     .filter(InteractionHistory.source_account_id == mastodon_account_id)
@@ -59,11 +53,7 @@ class BehavioralDetector(BaseDetector):
                     .limit(100)
                     .all()
                 )
-
-                unique_targets = set()
-                for interaction in recent_interactions:
-                    unique_targets.add(interaction.target_account_id)
-
+                unique_targets = {i.target_account_id for i in recent_interactions}
                 if len(unique_targets) >= rule.trigger_threshold:
                     violations.append(
                         Violation(
@@ -80,9 +70,7 @@ class BehavioralDetector(BaseDetector):
                             ),
                         )
                     )
-
             elif behavior_type == "daily_posting":
-                # Check for excessive daily posting
                 twenty_four_hours_ago = datetime.utcnow() - timedelta(hours=24)
                 posts_last_24h = (
                     session.query(InteractionHistory)
@@ -92,7 +80,6 @@ class BehavioralDetector(BaseDetector):
                     )
                     .count()
                 )
-
                 if posts_last_24h >= rule.trigger_threshold:
                     violations.append(
                         Violation(
@@ -105,11 +92,12 @@ class BehavioralDetector(BaseDetector):
                             ),
                         )
                     )
-
-            # Update or create AccountBehaviorMetrics
+            elif behavior_type == "automation_disclosure":
+                violations.extend(self._check_automation(rule, account_data, statuses))
+            elif behavior_type == "link_spam":
+                violations.extend(self._check_link_spam(rule, statuses))
             one_hour_ago = datetime.utcnow() - timedelta(hours=1)
             twenty_four_hours_ago = datetime.utcnow() - timedelta(hours=24)
-
             posts_last_1h = (
                 session.query(InteractionHistory)
                 .filter(
@@ -118,7 +106,6 @@ class BehavioralDetector(BaseDetector):
                 )
                 .count()
             )
-
             posts_last_24h = (
                 session.query(InteractionHistory)
                 .filter(
@@ -127,13 +114,11 @@ class BehavioralDetector(BaseDetector):
                 )
                 .count()
             )
-
             metrics = (
                 session.query(AccountBehaviorMetrics)
                 .filter(AccountBehaviorMetrics.mastodon_account_id == mastodon_account_id)
                 .first()
             )
-
             if not metrics:
                 metrics = AccountBehaviorMetrics(
                     mastodon_account_id=mastodon_account_id,
@@ -147,5 +132,99 @@ class BehavioralDetector(BaseDetector):
                 metrics.posts_last_24h = posts_last_24h
                 metrics.last_calculated_at = datetime.utcnow()
             session.commit()
-
         return violations
+
+    @staticmethod
+    def _parse_time(value: Any) -> datetime:
+        if isinstance(value, datetime):
+            return value
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+    def _check_automation(
+        self, rule: Rule, account_data: dict[str, Any], statuses: list[dict[str, Any]]
+    ) -> list[Violation]:
+        items = sorted(statuses, key=lambda s: self._parse_time(s["created_at"]), reverse=True)[:20]
+        if not items:
+            return []
+        texts = [re.sub(r"\d+", "", s.get("content", "")).strip().lower() for s in items]
+        counts: dict[str, list[int]] = {}
+        for i, text in enumerate(texts):
+            counts.setdefault(text, []).append(i)
+        duplicates = {i for idxs in counts.values() for i in idxs if len(idxs) > 1}
+        automation_percentage = len(duplicates) / len(items)
+        times = [self._parse_time(s["created_at"]) for s in items]
+        intervals = [abs((times[i] - times[i + 1]).total_seconds()) for i in range(len(times) - 1)]
+        avg_interval = sum(intervals) / len(intervals) if intervals else 0
+        results: list[Violation] = []
+        if not account_data.get("bot") and automation_percentage > 0.5:
+            matched_ids = [items[i]["id"] for i in sorted(duplicates) if items[i].get("id")]
+            results.append(
+                Violation(
+                    rule_name=rule.name,
+                    score=rule.weight,
+                    evidence=Evidence(
+                        matched_terms=[],
+                        matched_status_ids=matched_ids,
+                        metrics={"automation_percentage": automation_percentage, "average_interval": avg_interval},
+                    ),
+                )
+            )
+        if account_data.get("bot"):
+            now = datetime.utcnow()
+            public_items = [s for s in items if s.get("visibility") != "unlisted"]
+            posts_last_hour = sum(
+                1 for s in public_items if self._parse_time(s["created_at"]) >= now - timedelta(hours=1)
+            )
+            posts_last_day = sum(
+                1 for s in public_items if self._parse_time(s["created_at"]) >= now - timedelta(days=1)
+            )
+            if posts_last_hour > 1 or posts_last_day > 24:
+                matched_ids = [s["id"] for s in public_items if s.get("id")]
+                results.append(
+                    Violation(
+                        rule_name=rule.name,
+                        score=rule.weight,
+                        evidence=Evidence(
+                            matched_terms=[],
+                            matched_status_ids=matched_ids,
+                            metrics={"hourly_rate": posts_last_hour, "daily_rate": posts_last_day},
+                        ),
+                    )
+                )
+        return results
+
+    def _check_link_spam(self, rule: Rule, statuses: list[dict[str, Any]]) -> list[Violation]:
+        items = sorted(statuses, key=lambda s: self._parse_time(s["created_at"]), reverse=True)[:20]
+        total = len(items)
+        if total != 20:
+            return []
+        domain_counts: dict[str, int] = {}
+        content_map: dict[str, list[int]] = {}
+        links: list[tuple[int, list[str]]] = []
+        for i, status in enumerate(items):
+            content = status.get("content", "")
+            norm = re.sub(r"\s+", " ", content).strip().lower()
+            content_map.setdefault(norm, []).append(i)
+            found = re.findall(r"https?://[^\s]+", content)
+            if found:
+                links.append((i, found))
+                for link in found:
+                    domain = urlparse(link).netloc
+                    domain_counts[domain] = domain_counts.get(domain, 0) + 1
+        link_ratio = len(links) / total if total else 0
+        repetitive = any(len(idxs) > total / 2 for idxs in content_map.values())
+        single_domain = len(domain_counts) == 1
+        if link_ratio == 1 and (repetitive or single_domain):
+            matched_ids = [items[i]["id"] for i, _ in links if items[i].get("id")]
+            return [
+                Violation(
+                    rule_name=rule.name,
+                    score=rule.weight,
+                    evidence=Evidence(
+                        matched_terms=[],
+                        matched_status_ids=matched_ids,
+                        metrics={"link_ratio": link_ratio, "domain_distribution": domain_counts},
+                    ),
+                )
+            ]
+        return []

--- a/backend/app/services/detectors/behavioral_detector.py
+++ b/backend/app/services/detectors/behavioral_detector.py
@@ -197,7 +197,9 @@ class BehavioralDetector(BaseDetector):
     def _check_link_spam(self, rule: Rule, statuses: list[dict[str, Any]]) -> list[Violation]:
         items = sorted(statuses, key=lambda s: self._parse_time(s["created_at"]), reverse=True)[:20]
         total = len(items)
-        if total != 20:
+        items = sorted(statuses, key=lambda s: self._parse_time(s["created_at"]), reverse=True)[:self.LINK_SPAM_WINDOW_SIZE]
+        total = len(items)
+        if total != self.LINK_SPAM_WINDOW_SIZE:
             return []
         domain_counts: dict[str, int] = {}
         content_map: dict[str, list[int]] = {}

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -196,6 +196,11 @@ tests/                 # Comprehensive test suite
 
 Remote and local account polling both use a shared helper to keep the code simple.
 
+## Behavioral Detection
+
+- `automation_disclosure`: checks the last twenty posts for templates and steady timing. Non-bot accounts are flagged when more than half of posts look automated. Bots are flagged if they post publicly more than once an hour or twenty-four times a day.
+- `link_spam`: triggers when twenty recent posts all contain links and the content repeats or all links point to one domain. Metrics include link ratios and domain counts.
+
 ## Database Features
 
 ### Production-Ready Database Schema

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,16 @@ create_report_body_mod = types.ModuleType("app.clients.mastodon.models.create_re
 
 
 class CreateReportBody:
+    """Mock representation of a report body for testing purposes.
+
+    Attributes:
+        account_id: The ID of the account being reported.
+        comment: The comment associated with the report.
+        category: The category of the report.
+        forward: Whether the report should be forwarded.
+        status_ids: List of status IDs related to the report.
+        rule_ids: List of rule IDs related to the report.
+    """
     def __init__(self, account_id, comment, category, forward, status_ids, rule_ids):
         self.account_id = account_id
         self.comment = comment

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,9 +53,7 @@ def _get_account_sync(*_, **__):
 
 get_account_mod.sync = _get_account_sync
 
-get_account_statuses_mod = types.ModuleType(
-    "app.clients.mastodon.api.accounts.get_account_statuses"
-)
+get_account_statuses_mod = types.ModuleType("app.clients.mastodon.api.accounts.get_account_statuses")
 
 
 def _get_account_statuses_sync(*_, **__):
@@ -79,12 +77,10 @@ get_accounts_verify_credentials_mod.asyncio = _get_accounts_verify_credentials_s
 models_pkg = types.ModuleType("app.clients.mastodon.models")
 models_pkg.__path__ = []
 
-create_report_body_mod = types.ModuleType(
-    "app.clients.mastodon.models.create_report_body"
-)
+create_report_body_mod = types.ModuleType("app.clients.mastodon.models.create_report_body")
 
 
-class CreateReportBody:  # noqa: D401
+class CreateReportBody:
     def __init__(self, account_id, comment, category, forward, status_ids, rule_ids):
         self.account_id = account_id
         self.comment = comment
@@ -117,6 +113,24 @@ def _create_report_sync(*_, **__):
 
 
 create_report_mod.sync = _create_report_sync
+instance_pkg = types.ModuleType("app.clients.mastodon.api.instance")
+instance_pkg.__path__ = []
+get_instance_mod = types.ModuleType("app.clients.mastodon.api.instance.get_instance")
+
+
+def _get_instance_sync(*_, **__):
+    return None
+
+
+get_instance_mod.sync = _get_instance_sync
+get_instance_rules_mod = types.ModuleType("app.clients.mastodon.api.instance.get_instance_rules")
+
+
+def _get_instance_rules_sync(*_, **__):
+    return []
+
+
+get_instance_rules_mod.sync = _get_instance_rules_sync
 
 sys.modules.update(
     {
@@ -131,6 +145,9 @@ sys.modules.update(
         "app.clients.mastodon.models.create_report_body": create_report_body_mod,
         "app.clients.mastodon.api.reports": reports_pkg,
         "app.clients.mastodon.api.reports.create_report": create_report_mod,
+        "app.clients.mastodon.api.instance": instance_pkg,
+        "app.clients.mastodon.api.instance.get_instance": get_instance_mod,
+        "app.clients.mastodon.api.instance.get_instance_rules": get_instance_rules_mod,
     }
 )
 
@@ -182,9 +199,7 @@ def test_engine(test_settings):
 @pytest.fixture(scope="function")
 def test_db_session(test_engine):
     """Create a test database session that rolls back after each test."""
-    TestingSessionLocal = sessionmaker(
-        autocommit=False, autoflush=False, bind=test_engine
-    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=test_engine)
     session = TestingSessionLocal()
 
     try:


### PR DESCRIPTION
## Summary
- detect automation disclosure and link spam patterns
- document new behavioral detection rules
- exercise detector behaviors with focused tests

## Testing
- `PYTHONPATH=backend ruff check backend/app/services/detectors/behavioral_detector.py tests/conftest.py tests/services/test_detectors.py` (fails: Import block un-sorted, missing docstrings, module-level import order)
- `PYTHONPATH=backend make test` (fails: sqlite3 OperationalError: no such table: interaction_history, multiple assertion failures)


------
https://chatgpt.com/codex/tasks/task_e_689df5be4638832283be11a178a7a13f