### PR TITLE
feat: make legal notice configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,4 +180,4 @@ All API endpoints return structured error responses with:
 
 ## Legal Notice
 
-Every page shows a footer linking to [goingdark.social](https://goingdark.social). The app refuses to run without it. Don't remove or rename this credit; it's part of the license.
+The footer link and text come from settings stored in the database. Update them under the **Settings** tab. The default credit points to [goingdark.social](https://goingdark.social); keep an appropriate notice to meet the license.

--- a/backend/app/services/config_service.py
+++ b/backend/app/services/config_service.py
@@ -15,9 +15,7 @@ class ConfigService:
             row = session.get(Config, key)
             return row.value if row else None
 
-    def set_flag(
-        self, key: str, enabled: bool, updated_by: str | None = None
-    ) -> dict[str, bool]:
+    def set_flag(self, key: str, enabled: bool, updated_by: str | None = None) -> dict[str, bool]:
         """Store boolean flag in configuration."""
         with SessionLocal() as session:
             config = session.get(Config, key)
@@ -25,15 +23,11 @@ class ConfigService:
                 config.value = {"enabled": enabled}
                 config.updated_by = updated_by
             else:
-                session.add(
-                    Config(key=key, value={"enabled": enabled}, updated_by=updated_by)
-                )
+                session.add(Config(key=key, value={"enabled": enabled}, updated_by=updated_by))
             session.commit()
             return {"enabled": enabled}
 
-    def set_threshold(
-        self, key: str, threshold: float, updated_by: str | None = None
-    ) -> dict[str, float]:
+    def set_threshold(self, key: str, threshold: float, updated_by: str | None = None) -> dict[str, float]:
         """Store numeric threshold in configuration."""
         with SessionLocal() as session:
             config = session.get(Config, key)
@@ -41,11 +35,7 @@ class ConfigService:
                 config.value = {"threshold": threshold}
                 config.updated_by = updated_by
             else:
-                session.add(
-                    Config(
-                        key=key, value={"threshold": threshold}, updated_by=updated_by
-                    )
-                )
+                session.add(Config(key=key, value={"threshold": threshold}, updated_by=updated_by))
             session.commit()
             return {"threshold": threshold}
 
@@ -72,6 +62,19 @@ class ConfigService:
                 config.updated_by = updated_by
             else:
                 session.add(Config(key="automod", value=value, updated_by=updated_by))
+            session.commit()
+            return value
+
+    def set_legal_notice(self, url: str, text: str, updated_by: str | None = None) -> dict[str, str]:
+        """Store legal notice URL and text."""
+        with SessionLocal() as session:
+            config = session.get(Config, "legal_notice")
+            value = {"url": url, "text": text}
+            if config:
+                config.value = value
+                config.updated_by = updated_by
+            else:
+                session.add(Config(key="legal_notice", value=value, updated_by=updated_by))
             session.commit()
             return value
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,7 +56,7 @@ export default function App() {
   const [legalNoticeUrl, setLegalNoticeUrl] = useState('');
   const [legalNoticeText, setLegalNoticeText] = useState('');
   useEffect(() => {
-    if (!legalNoticeUrl || !legalNoticeText) return;
+    if (!legalNoticeUrl && !legalNoticeText) return;
     const timeoutId = setTimeout(() => {
       const link = document.querySelector(`a[href="${legalNoticeUrl}"]`);
       if (!link || link.textContent?.trim() !== legalNoticeText) {

--- a/tests/services/test_config_service.py
+++ b/tests/services/test_config_service.py
@@ -21,9 +21,7 @@ class TestConfigService(unittest.TestCase):
         Base.metadata.create_all(engine)
         self.SessionLocal = sessionmaker(bind=engine)
         self.service = ConfigService()
-        self.patcher = patch(
-            "app.services.config_service.SessionLocal", self.SessionLocal
-        )
+        self.patcher = patch("app.services.config_service.SessionLocal", self.SessionLocal)
         self.patcher.start()
 
     def tearDown(self):
@@ -55,6 +53,13 @@ class TestConfigService(unittest.TestCase):
         self.assertEqual(value["dry_run_override"], False)
         self.assertEqual(value["default_action"], "suspend")
         self.assertEqual(value["defederation_threshold"], 5)
+
+    def test_set_legal_notice(self):
+        """Store and retrieve legal notice."""
+        self.service.set_legal_notice("https://example.com", "Example", updated_by="tester")
+        value = self.service.get_config("legal_notice")
+        self.assertEqual(value["url"], "https://example.com")
+        self.assertEqual(value["text"], "Example")
 
 
 if __name__ == "__main__":

--- a/tests/test_authentication_authorization.py
+++ b/tests/test_authentication_authorization.py
@@ -334,6 +334,8 @@ class TestAuthenticationAuthorization(unittest.TestCase):
             "/analytics/timeline",
             "/config/dry_run",
             "/config/panic_stop",
+            "/config/legal_notice",
+            "/config",
             "/rules",
             "/scanning/federated",
             "/analytics/domains",
@@ -341,7 +343,13 @@ class TestAuthenticationAuthorization(unittest.TestCase):
 
         for endpoint in admin_endpoints:
             # Test unauthenticated access
-            if endpoint in ["/config/dry_run", "/config/panic_stop", "/rules", "/scanning/federated"]:
+            if endpoint in [
+                "/config/dry_run",
+                "/config/panic_stop",
+                "/config/legal_notice",
+                "/rules",
+                "/scanning/federated",
+            ]:
                 response = self.client.post(endpoint, json={})
             else:
                 response = self.client.get(endpoint)


### PR DESCRIPTION
## Summary
- store legal notice settings in database with new config endpoint
- load and edit legal notice through Settings tab
- cover legal notice in service and API tests

## Testing
- `make check` (fails: B008/D100 etc.)
- `PYTHONPATH=backend DATABASE_URL=sqlite:// UI_ORIGIN=http://localhost make test` (fails: multiple test failures)


------
https://chatgpt.com/codex/tasks/task_e_689efb629d00832290ab5a3690ffbb9f